### PR TITLE
Improve env setup

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+# Determine which Python interpreter to use
+if command -v python3.11 >/dev/null 2>&1; then
+    PYTHON_BIN="python3.11"
+else
+    PYTHON_BIN="python3"
+fi
+
 # Create virtual environment if it doesn't exist
 if [ ! -d "./venv" ]; then
-    python3 -m venv ./venv
+    "$PYTHON_BIN" -m venv ./venv
 fi
 
 # Activate the virtual environment


### PR DESCRIPTION
## Summary
- detect Python 3.11 when creating virtualenv

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_687f71bc0b94832caa223792e521bd79